### PR TITLE
Update time extraction code for all configured news sites

### DIFF
--- a/bbc.js
+++ b/bbc.js
@@ -1,14 +1,23 @@
 // BBC News date HTML:
-// <p class="date date--v1" data-seconds="1447545683"><strong>15 November 2015</strong> Last updated at 00:01 GMT </p>
-// OR: <div class="date date--v2" data-seconds="1352293816" data-datetime="7 November 2012">7 November 2012</div>
+// the date is embedded within the JSON metadata of a <script> element; the
+// object's key is called "datePublished".  If there is no <script> element
+// containing a "datePublished" key, then the publication date/time is stored
+// within a <time> element in the "datetime" attribute
 
 jQuery( function( $ ) {
 	// Extract the publication date from the page HTML
-	var published = '';
-	published = $( 'p[class="date date--v1"]' ).find( 'strong' ).text();
-	if ( published == '' ) {
-		published = $( 'div[class="date date--v2"]' ).attr( 'data-datetime');
-	}
+        var published = '';
+        let scripts = Array.from(document.querySelectorAll('script[type="application/ld+json"]'));
+        let scriptWithDatePublished = scripts.filter(
+            script => /datePublished/.test(script.innerText)
+        )[0];
+        if (scriptWithDatePublished !== '') {
+            let pageMetadta = JSON.parse(scriptWithDatePublished.innerText);
+            published = pageMetadta.datePublished;
+        }
+        else {
+            published = document.querySelector('time[data-testid="timestamp"').getAttribute('datetime');
+        }
 	
 	// Pass the date string to the date-checking function
 	dateCheck( published );

--- a/cnn.js
+++ b/cnn.js
@@ -1,19 +1,9 @@
 // CNN News date HTML:
-// <p class="update-time">Updated 1615 GMT (0015 HKT) November 5, 2015 <span id="js-pagetop_video_source" class="video__source top_source"></span></p>
-// OR: <div class="cnn_strytmstmp"><script type="text/javascript">if(location.hostname.indexOf( 'edition.' ) > -1) {document.write('January 13, 2010 -- Updated 1451 GMT (2251 HKT)');} else {document.write('January 13, 2010 9:51 a.m. EST');}</script></div>
+// <meta content="2021-08-07T00:32:40Z" name="pubdate">
 
 jQuery( function( $ ) {
 	// Extract the publication date from the page HTML
-	var published = '';
-	published = $( 'p[class="update-time"]' ).text();
-	published = published.replace( /^.*\)/i, '' );
-	published = published.replace( /\|.*$/i, '' );
-	
-	if ( published == '' ) {
-		published = $( 'div[class="cnn_strytmstmp"]' ).text();
-		published = published.replace( /^.*}/i, '' );
-		published = published.replace( /--.*$/i, '' );
-	}
+	var published = $( 'meta[name="pubdate"]' ).attr( 'content' );
 	
 	// Pass the date string to the date-checking function
 	dateCheck( published );

--- a/dailymail.js
+++ b/dailymail.js
@@ -1,9 +1,9 @@
 // (Current UK) Dailymail date HTML:
-// <meta itemprop="datePublished" content="2015-11-15T21:22:14+0000"/>
+// <meta property ="article:published_time" content="2021-08-07T00:43:23+0100" />
 
 jQuery( function( $ ) {
 	// Extract the publication date from the page HTML
-	var published = $( 'meta[itemprop="datePublished"]' ).attr( 'content' );
+	var published = $( 'meta[property="article:published_time"]' ).attr( 'content' );
 	
     // Pass the date string to the date-checking function
 	dateCheck( published );

--- a/huffingtonpost.js
+++ b/huffingtonpost.js
@@ -1,12 +1,9 @@
 // (Current) Huffington Post date HTML:
-// <span class="posted">
-//     Posted: <time datetime="2015-11-15T13:57:53-05:00">
-//     15/11/2015 18:57 GMT        </time>
-// </span>
+// <meta property="article:published_time" content="2021-08-06T14:08:48.000Z">
 
 jQuery( function( $ ) {
 	// Extract the publication date from the page HTML
-	var published = $( 'span[class="posted"]' ).find( 'time' ).attr( 'datetime' );
+	var published = $( 'meta[property="article:published_time"]' ).attr( 'content' );
 	
 	// Pass the date string to the date-checking function
 	dateCheck( published );

--- a/independent.js
+++ b/independent.js
@@ -1,10 +1,9 @@
 // (Current) Independent date HTML:
-// <li title="16 November 2015 18:19 London"><time data-microtimes='{"published":"1447684200000","display":"000","changed":"1447697948000"}' datetime="18:19, 16 November 2015"unixtime="1447697948000">Monday 16 November 2015 18:19 BST</time></li>
-
+// <meta property="article:published_time" content="2021-08-07T08:06:23.000Z">
 
 jQuery( function( $ ) {
 	// Extract the publication date from the page HTML
-	var published = $('time').attr('datetime').split(',')[1];
+	var published = $( 'meta[property="article:published_time"]' ).attr( 'content' );
 	
 	// Pass the date string to the date-checking function
 	dateCheck( published );

--- a/indiatimes.js
+++ b/indiatimes.js
@@ -1,10 +1,25 @@
 // India Times date HTML:
-// <div class="fl author_cont"><span class="fl"><img src="http://media.indiatimes.in/resources/images/indiatimes_author.jpg"/></span><div class="author_cont"><div class="author_fix"> By IndiaTimes</div><div>April 6, 2014</div></div></div></div></div>
+// <meta data-rh="true" property="article:published_time" content="Sat, 07 Aug 2021 10:40:41 GMT"/>
+// OR:
+// The date is embedded within the JSON metadata of a <script> element; the
+// object's key is called "datePublished"
 
 jQuery( function( $ ) {
 	// Extract the publication date from the page HTML
-	var published = $( 'div[class="fl author_cont"]' 
-		).find( 'div[class="author_cont"]' ).find( 'div:not([class])' ).text();
+        var published = '';
+	let published_time = $( 'meta[property="article:published_time"]' ).attr( 'content' );
+
+        if (published_time === undefined) {
+            let scripts = Array.from(document.querySelectorAll('script[type="application/ld+json"]'));
+            let scriptWithDatePublished = scripts.filter(
+                script => /datePublished/.test(script.innerText)
+            )[0];
+            let pageMetadta = JSON.parse(scriptWithDatePublished.innerText);
+            published = pageMetadta.datePublished;
+        }
+        else {
+            published = published_time;
+        }
 	
 	// Pass the date string to the date-checking function
 	dateCheck( published );

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,10 @@
 	
 	"content_scripts": [
 		{
-			"matches": [ "*://www.bbc.co.uk/news/*" ],
+			"matches": [
+				"*://www.bbc.co.uk/news/*",
+				"*://www.bbc.com/news/*"
+			],
 			"js":      [ "jquery-2.1.4.min.js", "date-check.js", "bbc.js" ]
 		},
 		{

--- a/manifest.json
+++ b/manifest.json
@@ -35,7 +35,8 @@
 		{
 			"matches": [
 				"*://www.huffingtonpost.co.uk/*",
-				"*://www.huffingtonpost.com/*"
+				"*://www.huffingtonpost.com/*",
+				"*://www.huffpost.com/*"
 			],
 			"js":      [ "jquery-2.1.4.min.js", "date-check.js", "huffingtonpost.js" ]
 		},

--- a/nytimes.js
+++ b/nytimes.js
@@ -1,16 +1,9 @@
 // New York Times date HTML:
-// <time class="dateline" datetime="2015-11-06" itemprop="datePublished" content="2015-11-06">NOV. 6, 2015</time>
-// OR: <div class="timestamp">Published: January 12, 2010 </div>
+// <meta data-rh="true" property="article:published_time" content="2021-08-07T09:00:26.000Z"/>
 
 jQuery( function( $ ) {
 	// Extract the publication date from the page HTML
-	var published = '';
-	published = $( 'time[itemprop="datePublished"]' ).attr( 'content' );
-	
-	if ( published == '' || !published ) {
-		published = $( 'div[class="timestamp"]' ).text();
-		published = published.replace( /Published: /, '' );
-	}
+	var published = $( 'meta[property="article:published_time"]' ).attr( 'content' );
 	
 	// Pass the date string to the date-checking function
 	dateCheck( published );

--- a/skynews.js
+++ b/skynews.js
@@ -1,14 +1,17 @@
 // (Current UK) Sky News
-// <script id="rich-snippet-article" type="application/ld+json">
-// {
-//         "datePublished": "2015-10-14T12:36:58+01:00",
+// the date is embedded within the JSON metadata of a <script> element; the
+// object's key is called "datePublished"
 
 jQuery( function( $ ) {
 	// Extract the publication date from the page HTML/script
-    var payload = $("#rich-snippet-article").html();
-    var json = JSON.parse(payload);
+        let scripts = Array.from(document.querySelectorAll('script[type="application/ld+json"]'));
+        let scriptWithDatePublished = scripts.filter(
+            script => /datePublished/.test(script.innerText)
+        )[0];
+        let pageMetadta = JSON.parse(scriptWithDatePublished.innerText);
+        let published = pageMetadta.datePublished;
 
 	// Pass the date string to the date-checking function
-	dateCheck( json.datePublished);
+	dateCheck( published );
 } );
 

--- a/stackoverflow.js
+++ b/stackoverflow.js
@@ -1,9 +1,9 @@
 // Stackoverflow Date HTML:
-// <p class="label-key" title="2014-06-02 16:57:19Z"><b>1 year ago</b></p>
+// <time itemprop="dateCreated" datetime="2021-08-07T10:45:44">today</time>
 
 jQuery( function( $ ) {
   // Extract the publication date from the page HTML
-  var published = $('table#qinfo td:contains("asked")').next('td').find('p').attr('title');
+  var published = $('time[itemprop="dateCreated"]').attr('datetime');
   
   // Pass the date string to the date-checking function
   dateCheck( published );

--- a/telegraph.js
+++ b/telegraph.js
@@ -1,9 +1,9 @@
 // (Current) Telegraph date HTML:
-// <meta itemprop="datePublished" content="2016-01-24"/>
+// <meta name="DCSext.articleFirstPublished" content="2021-08-07 07:24"/>
 
 jQuery( function( $ ) {
 	// Extract the publication date from the page HTML
-	var published = $( 'meta[itemprop="datePublished"]' ).attr( 'content' );
+	var published = $( 'meta[name="DCSext.articleFirstPublished"]' ).attr( 'content' );
 	
     // Pass the date string to the date-checking function
 	dateCheck( published );

--- a/theguardian.js
+++ b/theguardian.js
@@ -1,11 +1,9 @@
 // (Current UK) Guardian date HTML:
-// <time itemprop="datePublished" datetime='2015-11-14T12:00:05+0000'
-//   data-timestamp="1447502405000" class="content__dateline-wpd js-wpd">
-// Saturday 14 November 2015 <span class="content__dateline-time">12.00 GMT</span>
+// <meta property="article:published_time" content="2021-08-06T14:08:48.000Z">
 
 jQuery( function( $ ) {
 	// Extract the publication date from the page HTML
-	var published = $( 'time[itemprop="datePublished"]' ).attr( 'datetime' );
+	var published = $( 'meta[property="article:published_time"]' ).attr( 'content' );
 	
 	// Pass the date string to the date-checking function
 	dateCheck( published );

--- a/timesofindia.js
+++ b/timesofindia.js
@@ -1,28 +1,15 @@
 // Times of India date HTML:
-// <span style="margin-top:5px; display:block" class="byline">
-//	<span style="display: inline-block;vertical-align: middle;">
-//		<a class="italic" rel="author" href="/toireporter/author-Shariq-Majeed-479222339.cms">Shariq Majeed</a>
-//		<span class="hide_new" id="authortext">Shariq Majeed</span>
-//		,TNN
-//		<span>|</span>
-//		Oct 8, 2015, 06.56 AM IST
-//	</span>
-//	<div style="clear:both"></div>
-// </span>
+// the date is embedded within the JSON metadata of a <script> element; the
+// object's key is called "datePublished"
 
 jQuery( function( $ ) {
 	// Extract the publication date from the page HTML
-	var published;
-	$( 'span[class="byline"]' ).contents().each( function() {
-		// Within this iterator function, jQuery sets `this` to be
-		// each child node (including Text nodes, not just Elements)
-		if ( this.nodeType === 3 ) { // 3 = text node
-			if ( this.nodeValue.match( ' IST$' ) ) {
-				published = this.nodeValue;
-			}
-		}
-	});
-	published = published.replace( /,[^,]+$/, '' );
+        let scripts = Array.from(document.querySelectorAll('script[type="application/ld+json"]'));
+        let scriptWithDatePublished = scripts.filter(
+            script => /datePublished/.test(script.innerText)
+        )[0];
+        let pageMetadta = JSON.parse(scriptWithDatePublished.innerText);
+        let published = pageMetadta.datePublished;
 	
 	// Pass the date string to the date-checking function
 	dateCheck( published );

--- a/yahoo-uk.js
+++ b/yahoo-uk.js
@@ -1,9 +1,15 @@
 // (Current) Yahoo date HTML:
-// <abbr title="2012-08-23T10:58:41Z">Thu, Aug 23, 2012</abbr>
+// the date is embedded within the JSON metadata of a <script> element; the
+// object's key is called "datePublished"
 
 jQuery( function( $ ) {
 	// Extract the publication date from the page HTML
-	var published = $( 'abbr' ).attr( 'title' );
+        let scripts = Array.from(document.querySelectorAll('script[type="application/ld+json"]'));
+        let scriptWithDatePublished = scripts.filter(
+            script => /datePublished/.test(script.innerText)
+        )[0];
+        let pageMetadta = JSON.parse(scriptWithDatePublished.innerText);
+        let published = pageMetadta.datePublished;
 	
 	// Pass the date string to the date-checking function
 	dateCheck( published );

--- a/yahoo.js
+++ b/yahoo.js
@@ -1,9 +1,15 @@
 // (Current) Yahoo date HTML:
-// <abbr title="2012-08-23T10:58:41Z">Thu, Aug 23, 2012</abbr>
+// the date is embedded within the JSON metadata of a <script> element; the
+// object's key is called "datePublished"
 
 jQuery( function( $ ) {
 	// Extract the publication date from the page HTML
-	var published = $( 'abbr' ).text();
+        let scripts = Array.from(document.querySelectorAll('script[type="application/ld+json"]'));
+        let scriptWithDatePublished = scripts.filter(
+            script => /datePublished/.test(script.innerText)
+        )[0];
+        let pageMetadta = JSON.parse(scriptWithDatePublished.innerText);
+        let published = pageMetadta.datePublished;
 	
 	// Pass the date string to the date-checking function
 	dateCheck( published );


### PR DESCRIPTION
This PR updates the publication date/time extraction code for all sites defined in the extension's manifest file. In some cases it was necessary to extend the matches in the manifest as the news sites have changed their URLs slightly.  I've tried to document in each commit the changes that I made and why so that these changes can be cherry picked if so desired.

This PR is submitted in the hope that it is useful; if you want anything changed, I'll be more than happy to update and resubmit as necessary.